### PR TITLE
Add note about Android SDK dir to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $ keytool -genkey -keystore dummy-ks -alias dummy -keyalg RSA \
 
 ### Build a release APK
 
+> **Note**
+> Make sure that you have defined the Android SDK location via `ANDROID_HOME` environment variable or in sdk.dir path in `local.properties` file.
+
 ```bash
 $ ./gradlew assembleRelease
 ```


### PR DESCRIPTION
Hello!

While I was trying out `sigblock-code-poc`, I got the following error in the build step:

```
$ ./gradlew assembleRelease
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:lintVitalReportRelease'.
> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/home/orhun/gh/sigblock-code-poc/local.properties'.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
```

I fixed this after setting the `ANDROID_HOME` environment variable.

This PR simply adds a note about this to README.md
